### PR TITLE
Alternative prebuild script

### DIFF
--- a/dockerfiles/dendrite/prebuild.sh
+++ b/dockerfiles/dendrite/prebuild.sh
@@ -4,7 +4,7 @@
 touch /tmp/output
 sleep 5
 
-mvn -Dmaven.repo.local=/root/lib tomcat7:run -Dmaven.tomcat.port=8000 -Dspring.profiles.active=prod -DwithGitHistoryServer=true -Djava.security.egd=file:/dev/./urandom -DskipTests > /tmp/output 2>&1 &
+mvn -f /Dendrite/pom.xml -Dmaven.repo.local=/root/lib tomcat7:run -Dmaven.tomcat.port=8000 -Dspring.profiles.active=prod -DwithGitHistoryServer=true -Djava.security.egd=file:/dev/./urandom -DskipTests > /tmp/output 2>&1 &
 
 __started=false
 while [ "$__started" == "false" ]


### PR DESCRIPTION
For whatever reason, the previous one was getting in an endless loop on my machine.  Not sure if that's an issue on my end, but the following updates seemed to do the trick:
- touch output file to ensure it exists for while loop
- use single while loop that examines/greps last line of logfile
- echo progress while dendrite builds

As with the other pr, no rush
