### PR TITLE
startup.sh: Revert to original use of bin/ungit for port config

### DIFF
--- a/dockerfiles/dendrite/startup.sh
+++ b/dockerfiles/dendrite/startup.sh
@@ -2,10 +2,10 @@
 
 if [ -z "$SSL" ]; then
   PORT=$(curl --silent http://172.17.42.1:2375/containers/$HOSTNAME/json | jq '.NetworkSettings.Ports."8448/tcp"[].HostPort')
-  sed "s/port:.*/port: $PORT,/" -i /Dendrite/src/main/nodejs/ungit/source/config.js
+  sed "s/config.port/$PORT/g" -i /Dendrite/src/main/nodejs/ungit/bin/ungit
 else
   PORT=443
-  sed "s/port:.*/port: $PORT,/" -i /Dendrite/src/main/nodejs/ungit/source/config.js
   sed "s/port:.*/port: $PORT,/" -i /Dendrite/src/main/webapp/js/app.js;
+  sed "s/config.port/$PORT/g" -i /Dendrite/src/main/nodejs/ungit/bin/ungit
   sed "s|\"\"|\"/dendrite2\"|" -i /Dendrite/src/main/nodejs/ungit/bin/ungit
 fi


### PR DESCRIPTION
Apologies: Updating the config.js file prevents the ungit server from starting up correctly; revert to use of bin/ungit to resolve issue
